### PR TITLE
fix structure_factor_spline bug

### DIFF
--- a/source/lattice_sum.cpp
+++ b/source/lattice_sum.cpp
@@ -145,13 +145,13 @@ Complex3D structure_factor_spline(
         return r;
     };
 
+    // compute fractional coordinates and make sure they lie in [0,1)
     std::vector<std::array<double,3>> frac_coords(xyz_coords.size());
     for (size_t i=0; i<frac_coords.size(); ++i) {
         frac_coords[i] = m_dot_v(ainv, xyz_coords[i]);
         for (size_t j=0; j<3; ++j) {
-            // compute fractional coordinates and make sure they lie in [0,1)
-            // the duplicated operation is intentional as a single operation fails to treat 
-            // small, negative values (e.g. -1e-20) that might be mapped to 1 instead of 0
+            // both lines are necessary as a single operation can fail for small
+            // negative values (e.g. -1e-20), mapping them to 1.0 instead of 0.0
             frac_coords[i][j] -= std::floor(frac_coords[i][j]);
             frac_coords[i][j] -= std::floor(frac_coords[i][j]);
         }

--- a/source/lattice_sum.cpp
+++ b/source/lattice_sum.cpp
@@ -144,7 +144,6 @@ Complex3D structure_factor_spline(
         r[2] = m[2][0]*v[0] + m[2][1]*v[1] + m[2][2]*v[2];
         return r;
     };
-
     // compute fractional coordinates and make sure they lie in [0,1)
     std::vector<std::array<double,3>> frac_coords(xyz_coords.size());
     for (size_t i=0; i<frac_coords.size(); ++i) {

--- a/source/lattice_sum.cpp
+++ b/source/lattice_sum.cpp
@@ -144,12 +144,17 @@ Complex3D structure_factor_spline(
         r[2] = m[2][0]*v[0] + m[2][1]*v[1] + m[2][2]*v[2];
         return r;
     };
-    // compute fractional coordinates
+
     std::vector<std::array<double,3>> frac_coords(xyz_coords.size());
     for (size_t i=0; i<frac_coords.size(); ++i) {
         frac_coords[i] = m_dot_v(ainv, xyz_coords[i]);
-        //for (size_t j=0; j<3; ++j)
-        //    frac_coords[i][j] -= std::floor(frac_coords[i][j]);
+        for (size_t j=0; j<3; ++j) {
+            // compute fractional coordinates and make sure they lie in [0,1)
+            // the duplicated operation is intentional as a single operation fails to treat 
+            // small, negative values (e.g. -1e-20) that might be mapped to 1 instead of 0
+            frac_coords[i][j] -= std::floor(frac_coords[i][j]);
+            frac_coords[i][j] -= std::floor(frac_coords[i][j]);
+        }
     }
 
     int N0 = shape[0];


### PR DESCRIPTION
This pull request is to fix a bug associated with the structure factor splines. The following test code uses `Phonopy` to generate a 4 x 4 x 4 supercell of atoms whose structure factor is to be evaluated by `deft.structure_factor_spline()`. The script was ran in the `deft/example` directory.
```
import numpy as np

from phonopy import Phonopy
from phonopy.structure.atoms import PhonopyAtoms

import os
import sys
sys.path.append(os.path.join(os.getcwd(), '../build/'))
import pydeft as deft

a = 4.07
box_vecs = a * np.array([[0.0, 0.5, 0.5],
                         [0.5, 0.0, 0.5],
                         [0.5, 0.5, 0.0]])
frac_ion_coords = np.zeros((1, 3))

unitcell = PhonopyAtoms(symbols=(['Al'] * 1), cell=box_vecs, scaled_positions=[(0, 0, 0)])
supercell_matrix = [[4, 0, 0], [0, 4, 0], [0, 0, 4]]
phonon = Phonopy(unitcell, supercell_matrix, primitive_matrix=np.identity(3))
supercell = phonon.supercell
box_vecs = supercell.cell
positions = supercell.positions

shape = (47,47,47)
frac_ion_coords = np.matmul(positions, np.linalg.inv(box_vecs))
str_fac_spline = deft.structure_factor_spline(shape, deft.Box(box_vecs), positions, 20)
```
This results in the error `RuntimeError: cardinal_b_spline_values: invalid x`.

The fix proposed to prevent this error is to ensure that the fractional ion coordinates lie in the range [0,1), which involves performing the operation `frac_coords[i][j] -= std::floor(frac_coords[i][j])` twice. Doing it twice is a precautionary measure as one special case I faced in my equivalent Python code was when `x=frac_coords[i][j]` was a small negative value like `-1e-16`. Performing the operation once translated it to `x=1.0` (which should be excluded) and the second run translates it to `x=0.0` which is in the required range. 